### PR TITLE
Small bug fixes

### DIFF
--- a/src/main/java/swg/gui/resources/SWGHarvester.java
+++ b/src/main/java/swg/gui/resources/SWGHarvester.java
@@ -843,6 +843,7 @@ public final class SWGHarvester implements Serializable, Comparable<SWGHarvester
      */
     void refreshHopperEmptied() {
     	hopperEmptied = System.currentTimeMillis();
+    	hopperFull = false;
     }
 
     /**

--- a/src/main/java/swg/gui/resources/SWGInventoryTab.java
+++ b/src/main/java/swg/gui/resources/SWGInventoryTab.java
@@ -2693,8 +2693,8 @@ public final class SWGInventoryTab extends JPanel {
 
                     public int compare(SWGInventoryWrapper w1,
                             SWGInventoryWrapper w2) {
-                        double d1 = wgt.rate(w1.getResource(), cls, true, useJTLcap);
-                        double d2 = wgt.rate(w2.getResource(), cls, true, useJTLcap);
+                        double d1 = wgt.rate(w1.getResource(), cls, true, false);
+                        double d2 = wgt.rate(w2.getResource(), cls, true, false);
                         return Double.compare(d1, d2);
                     }
                 };


### PR DESCRIPTION
* Fixed issue where having the new JTL resource option enabled and user attempts to sort a weighted list on the inventory tab, the table would generate an error drawing. This was introduced by the new feature.

* Fixed an issue where a harvester could get stuck thinking its inventory was full after using the "empty only" option and would show incorrect values. This appears to have been there for a long time.